### PR TITLE
export fn*

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -2,4 +2,4 @@
 
 (defpackage #:fn
   (:use #:cl)
-  (:export :fn% :fn~ :fn~r :fn+ :fn-reader))
+  (:export :fn* :fn% :fn~ :fn~r :fn+ :fn-reader))


### PR DESCRIPTION
It seems `fn*` isn't actually exported by this package even though it's mentioned in the README. This fixes that.