### PR TITLE
Support Lispworks.

### DIFF
--- a/fn.lisp
+++ b/fn.lisp
@@ -136,22 +136,22 @@ and then calling the next one with the primary value of the last."
   (let* ((body (read stream t nil t)))
     (fn*-internals body nil)))
 
-#-abcl
+#-(or abcl lispworks)
 (named-readtables:defreadtable fn-reader
     (:merge :standard)
   (:macro-char #\GREEK_SMALL_LETTER_LAMDA #'lambda-reader t))
 
-#-abcl
+#-(or abcl lispworks)
 (named-readtables:defreadtable :fn.reader
     (:merge :standard)
 	(:macro-char #\GREEK_SMALL_LETTER_LAMDA #'lambda-reader t))
 
-#+abcl
+#+(or abcl lispworks)
 (named-readtables:defreadtable fn-reader
     (:merge :standard)
   (:macro-char #\λ #'lambda-reader t))
 
-#+abcl
+#+(or abcl lispworks)
 (named-readtables:defreadtable :fn.reader
     (:merge :standard)
   (:macro-char #\λ #'lambda-reader t))


### PR DESCRIPTION
Lispworks does not recognize the "#\GREEK_SMALL_LETTER_LAMDA", it does recognize the greek symbol.