### PR TITLE
Add Lispworks to the exclusion for the "lambda letter"

### DIFF
--- a/fn.lisp
+++ b/fn.lisp
@@ -136,12 +136,12 @@ and then calling the next one with the primary value of the last."
   (let* ((body (read stream t nil t)))
     (fn*-internals body nil)))
 
-#-abcl
+#-(or lispworks abcl)
 (named-readtables:defreadtable fn-reader
     (:merge :standard)
   (:macro-char #\GREEK_SMALL_LETTER_LAMDA #'lambda-reader t))
 
-#-abcl
+#-(or lispworks abcl)
 (named-readtables:defreadtable :fn.reader
     (:merge :standard)
 	(:macro-char #\GREEK_SMALL_LETTER_LAMDA #'lambda-reader t))


### PR DESCRIPTION
Added this because attempting to `quickload` this package fails on Lispworks.

Current error, for reference:

```
**++++ Error between functions:
  Wrong character name: GREEK_SMALL_LETTER_LAMDA.

**++++ Error between functions:
  Wrong character name: GREEK_SMALL_LETTER_LAMDA.
; *** 2 errors detected, no fasl file produced.

Error: COMPILE-FILE-ERROR while compiling #<ASDF/LISP-ACTION:CL-SOURCE-FILE "fn" "fn">
  1 (continue) Retry compiling #<ASDF/LISP-ACTION:CL-SOURCE-FILE "fn" "fn">.
  2 Continue, treating compiling #<ASDF/LISP-ACTION:CL-SOURCE-FILE "fn" "fn"> as having been successful.
  3 Retry ASDF operation.
```


